### PR TITLE
FFS-2174 Bruk felles GitHub workflows

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -1,95 +1,18 @@
 name: CD Deploy
 
 on:
-    workflow_run:
-        workflows:
-            - CI Build
-        types:
-            - completed
-
-env:
-    REGISTRY: ghcr.io
-
-permissions:
-    contents: read
-    packages: read
+  workflow_run:
+    workflows:
+      - CI Build
+    types:
+      - completed
 
 jobs:
-    deploy-to-aks:
-        if: >
-            github.event.workflow_run.conclusion == 'success' &&
-            github.event.workflow_run.head_branch == 'main'
-
-        runs-on: ubuntu-latest
-
-        strategy:
-            matrix:
-                org:
-                    - fintlabs-no
-
-                cluster:
-                    - aks-beta-fint-2021-11-23
-
-        steps:
-            - name: Checkout source
-              uses: actions/checkout@v7
-
-            - name: Derive lowercase image name
-              run: echo "IMAGE_NAME=$(echo "$GITHUB_REPOSITORY" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
-
-            - name: Log in to GHCR
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Pull image
-              run: docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
-
-            - name: Determine environment
-              id: environment
-              uses: actions/github-script@v9
-              with:
-                  script: return '${{ matrix.cluster }}'.split('-')[1];
-                  result-encoding: string
-
-            - name: Determine resource group
-              id: resource-group
-              uses: actions/github-script@v9
-              with:
-                  script: return 'rg-aks-${{ steps.environment.outputs.result }}';
-                  result-encoding: string
-
-            - name: Bake manifests
-              id: bake
-              uses: azure/k8s-bake@v4
-              with:
-                  renderEngine: kustomize
-                  kustomizationPath: kustomize/overlays/${{ matrix.org }}/${{ steps.environment.outputs.result }}
-
-            - name: Azure login
-              uses: azure/login@v2
-              with:
-                  creds: ${{ secrets[format('AKS_{0}_FINT_GITHUB', steps.environment.outputs.result)] }}
-
-            - name: Install kubelogin
-              uses: azure/use-kubelogin@v1
-              with:
-                  kubelogin-version: 'v0.2.12'
-
-            - name: Set AKS context
-              uses: azure/aks-set-context@v5
-              with:
-                  cluster-name: ${{ matrix.cluster }}
-                  resource-group: ${{ steps.resource-group.outputs.result }}
-                  admin: true
-                  use-kubelogin: true
-
-            - name: Deploy to AKS
-              uses: azure/k8s-deploy@v5.0.4
-              with:
-                  action: deploy
-                  manifests: ${{ steps.bake.outputs.manifestsBundle }}
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.event.workflow_run.head_sha }}
-                  namespace: ${{ matrix.org }}
+  deploy:
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-cd-deploy.yaml@main
+    with:
+      deploy-targets: |
+        [
+          {"org":"fintlabs-no","cluster":"aks-beta-fint-2021-11-23"}
+        ]
+    secrets: inherit

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
     with:
       push-image: ${{ github.event_name == 'push' }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,56 +1,14 @@
 name: CI Build
 
 on:
-    pull_request:
-    push:
-        branches:
-            - main
-
-env:
-    REGISTRY: ghcr.io
-
-permissions:
-    contents: read
-    packages: write
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
-    build:
-        name: Build & Publish Image
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Checkout source
-              uses: actions/checkout@v7
-
-            - name: Set up Java 25
-              uses: actions/setup-java@v5
-              with:
-                  distribution: temurin
-                  java-version: '25'
-
-            - name: Set up Gradle
-              uses: gradle/actions/setup-gradle@v6
-              with:
-                  gradle-version: wrapper
-
-            - name: Build with Gradle
-              run: ./gradlew build
-
-            - name: Derive lowercase image name
-              run: echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-            - name: Log in to GHCR
-              if: github.event_name == 'push'
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - id: build-image
-              name: Build & Push Docker image
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  push: ${{ github.event_name == 'push' }}
-                  tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+  build:
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
+    with:
+      push-image: ${{ github.event_name == 'push' }}
+    secrets: inherit

--- a/.github/workflows/MD.yaml
+++ b/.github/workflows/MD.yaml
@@ -1,146 +1,32 @@
 name: MD
 
 on:
-    workflow_dispatch:
-        inputs:
-            cluster:
-                description: Select an environment
-                required: true
-                type: choice
-                options:
-                    - aks-beta-fint-2021-11-23
-                    - aks-api-fint-2022-02-08
-            org:
-                description: Select organisation
-                required: true
-                type: choice
-                options:
-                    - afk-no
-                    - agderfk-no
-                    - bfk-no
-                    - ffk-no
-                    - fintlabs-no
-                    - innlandetfylke-no
-                    - mrfylke-no
-                    - nfk-no
-                    - ofk-no
-                    - rogfk-no
-                    - telemarkfylke-no
-                    - tromsfylke-no
-                    - trondelagfylke-no
-                    - vestfoldfylke-no
-                    - vlfk-no
-
-env:
-    REGISTRY: ghcr.io
-    CLUSTER_NAME: ${{ inputs.cluster }}
-    ORG: ${{ inputs.org }}
-
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: Select environment
+        required: true
+        type: choice
+        options:
+          - aks-beta-fint-2021-11-23
+      org:
+        description: Select organisation
+        required: true
+        type: choice
+        options:
+          - fintlabs-no
 jobs:
-    deploy:
-        runs-on: ubuntu-latest
+  build:
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
+    with:
+      push-image: true
+    secrets: inherit
 
-        permissions:
-            contents: read
-            packages: write
-
-        concurrency:
-            group: manual-deploy-${{ inputs.cluster }}-${{ inputs.org }}
-            cancel-in-progress: false
-
-        steps:
-            - name: Determine resource group
-              id: rg
-              uses: actions/github-script@v9
-              with:
-                  script: |
-                      const p = '${{ inputs.cluster }}'.split('-');
-                      return `rg-${p[0]}-${p[1]}`;
-                  result-encoding: string
-
-            - name: Determine environment
-              id: environment
-              uses: actions/github-script@v9
-              with:
-                  script: return '${{ inputs.cluster }}'.split('-')[1];
-                  result-encoding: string
-
-            - name: Checkout source
-              uses: actions/checkout@v7
-
-            - name: Set up Java 25
-              uses: actions/setup-java@v5
-              with:
-                  distribution: temurin
-                  java-version: '25'
-
-            - name: Set up Gradle
-              uses: gradle/actions/setup-gradle@v6
-              with:
-                  gradle-version: wrapper
-
-            - name: Build
-              run: ./gradlew build
-
-            - name: Derive lowercase image name
-              run: echo "IMAGE_NAME=$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
-            - name: Log in to GHCR
-              uses: docker/login-action@v4
-              with:
-                  registry: ${{ env.REGISTRY }}
-                  username: ${{ github.actor }}
-                  password: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Generate Docker metadata
-              id: meta
-              uses: docker/metadata-action@v5
-              with:
-                  images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                  tags: type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
-
-            - name: Build & Push Docker image
-              uses: docker/build-push-action@v7
-              with:
-                  context: .
-                  push: true
-                  tags: ${{ steps.meta.outputs.tags }}
-                  labels: ${{ steps.meta.outputs.labels }}
-
-            - name: Bake manifests
-              id: bake
-              uses: azure/k8s-bake@v4
-              with:
-                  renderEngine: kustomize
-                  kustomizationPath: kustomize/overlays/${{ env.ORG }}/${{ steps.environment.outputs.result }}
-
-            - name: Determine secret name
-              id: secretname
-              run: |
-                  echo "SECRET_NAME=$(echo AKS_${{ steps.environment.outputs.result }}_FINT_GITHUB | tr '[:lower:]' '[:upper:]')" >> "$GITHUB_OUTPUT"
-
-            - name: Azure login
-              uses: azure/login@v2
-              with:
-                  creds: ${{ secrets[steps.secretname.outputs.SECRET_NAME] }}
-
-            - name: Install kubelogin
-              uses: azure/use-kubelogin@v1
-              with:
-                  kubelogin-version: 'v0.2.12'
-
-            - name: Set AKS context
-              uses: azure/aks-set-context@v5
-              with:
-                  cluster-name: ${{ env.CLUSTER_NAME }}
-                  resource-group: ${{ steps.rg.outputs.result }}
-                  admin: true
-                  use-kubelogin: true
-
-            - name: Deploy to AKS
-              uses: azure/k8s-deploy@v5.0.4
-              with:
-                  action: deploy
-                  manifests: ${{ steps.bake.outputs.manifestsBundle }}
-                  images: ${{ steps.meta.outputs.tags }}
-                  namespace: ${{ env.ORG }}
+  deploy:
+    needs: build
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-deploy-aks.yaml@main
+    with:
+      org: ${{ inputs.org }}
+      cluster: ${{ inputs.cluster }}
+      image-ref: ${{ needs.build.outputs.image-ref }}
+    secrets: inherit

--- a/.github/workflows/MD.yaml
+++ b/.github/workflows/MD.yaml
@@ -17,6 +17,9 @@ on:
           - fintlabs-no
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-app-build-image.yaml@main
     with:
       push-image: true


### PR DESCRIPTION
## Summary
- Replace repository-local CI/CD/MD implementation with reusable workflows from `FINTLabs/fint-flyt-github-workflows`.
- Keep repository-specific deploy targets based on existing `kustomize/overlays`.

## Validation
- YAML parse completed for changed workflow files.
- `git diff --check` completed.
- Deploy targets were verified against existing overlays.