### PR TITLE
FFS-2190: Oppgrader gateway-template til gateway-starter 4.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("no.novari:flyt-gateway-starter:3.1.0")
+    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-1")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-3")
+    implementation("no.novari:flyt-gateway-starter:4.0.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-2")
+    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-3")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-1")
+    implementation("no.novari:flyt-gateway-starter:4.0.0-rc-2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")


### PR DESCRIPTION
## Summary

Implements [FFS-2190](https://novari-iks.atlassian.net/browse/FFS-2190).

- Oppgraderer til `flyt-gateway-starter:4.0.0`.
- Arver web-resource-server 4.0.0 gjennom gateway-starter uten direkte avhengighet.

[FFS-2190]: https://novari-iks.atlassian.net/browse/FFS-2190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ