### PR TITLE
FFS-1846 Bruk delt CodeQL-workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,20 @@
+name: CodeQL
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "24 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze Java/Kotlin
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    uses: FINTLabs/fint-flyt-github-workflows/.github/workflows/java-codeql.yaml@main
+    secrets: inherit


### PR DESCRIPTION
## Sammendrag

Legger til `.github/workflows/codeql.yaml`, som var det siste repoet-settet uten CodeQL-dekning. Filen er identisk med den som allerede brukes i de øvrige repoene i porteføljen: en tynn wrapper som kaller den delte workflowen `FINTLabs/fint-flyt-github-workflows/.github/workflows/java-codeql.yaml@main`.

Analysen kjører på pull request, på push til `main`, og ukentlig (mandag 03:24). Selve konfigurasjonen — Java-versjon, byggekommando og språk — ligger i den delte workflowen, ikke her.

Se [FFS-1846](https://novari-iks.atlassian.net/browse/FFS-1846).

[FFS-1846]: https://novari-iks.atlassian.net/browse/FFS-1846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ