### PR TITLE
FFS-2278 Kjør Dependabot på mandag og legg til CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FINTLabs/flyt_backend

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 10
@@ -42,7 +42,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 5
@@ -50,7 +50,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       groups:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,9 @@ repositories {
     mavenLocal()
 }
 
+extra["httpclient5.version"] = "5.6.3"
+extra["httpcore5.version"] = "5.4.3"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-actuator")


### PR DESCRIPTION
## Sammendrag

Flytter Dependabot-kjøringen fra onsdag til mandag, og legger til `.github/CODEOWNERS` med `* @FINTLabs/flyt_backend` — samme oppsett som i de øvrige repoene eid av teamet.

Dette repoet har ingen åpne Dependabot-alerts, så det er ingen versjonsoverstyringer her slik de andre FFS-2278-PR-ene har. Endringen er ren konfigurasjon.

Se [FFS-2278](https://novari-iks.atlassian.net/browse/FFS-2278).

[FFS-2278]: https://novari-iks.atlassian.net/browse/FFS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ