### PR TITLE
FFS-2278 Overstyr sårbare avhengighetsversjoner i malen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,8 +29,16 @@ repositories {
 
 extra["httpclient5.version"] = "5.6.3"
 extra["httpcore5.version"] = "5.4.3"
+extra["jackson-bom.version"] = "2.21.5"
+extra["log4j2.version"] = "2.25.5"
 
 dependencies {
+    constraints {
+        implementation("at.yawk.lz4:lz4-java:1.11.2") {
+            because("Fixes CVE-2026-59949 in the kafka-clients transitive dependency")
+        }
+    }
+
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")


### PR DESCRIPTION
## Sammendrag

- `jackson-bom` → 2.21.5 (var 2.21.4)
- `log4j2` → 2.25.5 (var 2.24.3)
- `at.yawk.lz4:lz4-java` → 1.11.2 (var 1.10.1, via kafka-clients)

## Hvorfor dette ikke kom med i #31

Overstyringene i FFS-2278 ble skreddersydd per repo ut fra hvilke Dependabot-alerts hvert repo faktisk hadde. Dette repoet hadde **null alerts** — ikke fordi det var trygt, men fordi GitHub Actions var avslått, så Automatic Dependency Submission aldri kjørte og dependency-grafen var tom.

`httpcore5` og `httpclient5` kom med i #31 fordi de ble funnet gjennom en manuell classpath-gjennomgang, ikke via alerts. De tre over ble ikke fanget opp på samme måte.

Actions er nå slått på, med `CD Deploy` og `MD` deaktivert som enkeltworkflows slik at malen bygges og skannes uten å deployes. Når denne merges kjører submission for første gang, og alert-bildet blir reelt.

Verifisert med `dependencyInsight` på `runtimeClasspath`, og `gradle check` er grønn.

Se [FFS-2278](https://novari-iks.atlassian.net/browse/FFS-2278).

[FFS-2278]: https://novari-iks.atlassian.net/browse/FFS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ